### PR TITLE
Revert commit 4664677a4e for solarized-dark.reg

### DIFF
--- a/solarized-dark.reg
+++ b/solarized-dark.reg
@@ -8,7 +8,7 @@ Windows Registry Editor Version 5.00
 ;
 ; NR  cmd.exe      PowerShell   SOLARIZED  HEX      DWORD
 ; --  -------      -----------  ---------  -------  --------
-; 00  Black        Black        base02     #073642  00423607
+; 00  Black        Black        base03     #002b36  00362b00
 ; 01  Blue         DarkBlue     base0      #839496  00969483
 ; 02  Green        DarkGreen    base01     #586e75  00756e58
 ; 03  Aqua         DarkCyan     base1      #93a1a1  00a1a193
@@ -16,7 +16,7 @@ Windows Registry Editor Version 5.00
 ; 05  Purple       DarkMagenta  violet     #6c71c4  00c4716c
 ; 06  Yellow       DarkYellow   base00     #657b83  00837b65
 ; 07  White        Gray         base2      #eee8d5  00d5e8ee
-; 08  Gray         DarkGray     base03     #002b36  00362b00
+; 08  Gray         DarkGray     base02     #073642  00423607
 ; 09  LightBlue    Blue         blue       #268bd2  00d28b26
 ; 10  LightGreen   Green        green      #859900  00009985
 ; 11  LightAqua    Cyan         cyan       #2aa198  0098a12a
@@ -27,7 +27,7 @@ Windows Registry Editor Version 5.00
 ;
 
 [HKEY_CURRENT_USER\Console]
-"ColorTable00"=dword:00423607
+"ColorTable00"=dword:00362b00
 "ColorTable01"=dword:00969483
 "ColorTable02"=dword:00756e58
 "ColorTable03"=dword:00a1a193
@@ -35,7 +35,7 @@ Windows Registry Editor Version 5.00
 "ColorTable05"=dword:00c4716c
 "ColorTable06"=dword:00837b65
 "ColorTable07"=dword:00d5e8ee
-"ColorTable08"=dword:00362b00
+"ColorTable08"=dword:00423607
 "ColorTable09"=dword:00d28b26
 "ColorTable10"=dword:00009985
 "ColorTable11"=dword:0098a12a
@@ -43,5 +43,5 @@ Windows Registry Editor Version 5.00
 "ColorTable13"=dword:008236d3
 "ColorTable14"=dword:000089b5
 "ColorTable15"=dword:00e3f6fd
-"ScreenColors"=dword:00000081
+"ScreenColors"=dword:00000001
 "PopupColors"=dword:000000f6

--- a/solarized-light.reg
+++ b/solarized-light.reg
@@ -8,7 +8,7 @@ Windows Registry Editor Version 5.00
 ;
 ; NR  cmd.exe      PowerShell   SOLARIZED  HEX      DWORD
 ; --  -------      -----------  ---------  -------  --------
-; 00  Black        Black        base02     #073642  00423607
+; 00  Black        Black        base03     #002b36  00362b00
 ; 01  Blue         DarkBlue     base0      #839496  00969483
 ; 02  Green        DarkGreen    base01     #586e75  00756e58
 ; 03  Aqua         DarkCyan     base1      #93a1a1  00a1a193
@@ -16,7 +16,7 @@ Windows Registry Editor Version 5.00
 ; 05  Purple       DarkMagenta  violet     #6c71c4  00c4716c
 ; 06  Yellow       DarkYellow   base00     #657b83  00837b65
 ; 07  White        Gray         base2      #eee8d5  00d5e8ee
-; 08  Gray         DarkGray     base03     #002b36  00362b00
+; 08  Gray         DarkGray     base02     #073642  00423607
 ; 09  LightBlue    Blue         blue       #268bd2  00d28b26
 ; 10  LightGreen   Green        green      #859900  00009985
 ; 11  LightAqua    Cyan         cyan       #2aa198  0098a12a
@@ -27,7 +27,7 @@ Windows Registry Editor Version 5.00
 ;
 
 [HKEY_CURRENT_USER\Console]
-"ColorTable00"=dword:00423607
+"ColorTable00"=dword:00362b00
 "ColorTable01"=dword:00969483
 "ColorTable02"=dword:00756e58
 "ColorTable03"=dword:00a1a193
@@ -35,7 +35,7 @@ Windows Registry Editor Version 5.00
 "ColorTable05"=dword:00c4716c
 "ColorTable06"=dword:00837b65
 "ColorTable07"=dword:00d5e8ee
-"ColorTable08"=dword:00362b00
+"ColorTable08"=dword:00423607
 "ColorTable09"=dword:00d28b26
 "ColorTable10"=dword:00009985
 "ColorTable11"=dword:0098a12a
@@ -44,4 +44,4 @@ Windows Registry Editor Version 5.00
 "ColorTable14"=dword:000089b5
 "ColorTable15"=dword:00e3f6fd
 "ScreenColors"=dword:000000f6
-"PopupColors"=dword:00000081
+"PopupColors"=dword:00000001


### PR DESCRIPTION
- Committ [4664677a4e](https://github.com/neilpa/cmd-colors-solarized/commit/4664677a4eedc25ca1713a42dc43586902e554ae#diff-78deea8aa8cd814c85b0251e6e692668) made zero effective changes to the scheme other than swapping assignments. (Color assignments of color 00 and color 08 were swapped and `ScreenColors` to match the new assignment.
- Reverting this commit ensures identical color palettes for both dark
  and light schemes with the only difference that `ScreenColors` and
  `PopupColors` are swapped for each scheme
- Cleans up extra line space and extra line in solarized-light.reg so
  both files have matched formatting
