### PR TITLE
Feature/update for start menu

### DIFF
--- a/Update-StartMenu.cmd
+++ b/Update-StartMenu.cmd
@@ -1,0 +1,2 @@
+@ECHO OFF
+PowerShell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dpn0.ps1" %*

--- a/Update-StartMenu.ps1
+++ b/Update-StartMenu.ps1
@@ -1,3 +1,8 @@
+param(
+    [Parameter()]
+    [ValidateSet('Light','Dark')]
+    [string]$theme = 'Dark'
+)
 
 Write-Host "Updating PowerShell shortcuts on the Start Menu"
 
@@ -11,7 +16,7 @@ Write-Host
 $powerShellx86 = "$powerShellFolder\Windows PowerShell (x86).lnk"
 if (test-path $powerShellx86) {
     Write-Host "Updating $powerShellx86"
-    .\Update-Link.ps1 $powerShellx86
+    .\Update-Link.ps1 $powerShellx86 $theme
 } else {
     Write-Warning "Didn't find $powerShellx86"
 }
@@ -20,7 +25,7 @@ Write-Host
 $powerShell64 = "$powerShellFolder\Windows PowerShell.lnk" 
 if (test-path $powerShell64) {
     Write-Host "Updating $powerShell64"
-    .\Update-Link.ps1 $powerShell64
+    .\Update-Link.ps1 $powerShell64 $theme
 } else {
     Write-Warning "Didn't find $powerShell64"
 }

--- a/Update-StartMenu.ps1
+++ b/Update-StartMenu.ps1
@@ -1,0 +1,26 @@
+
+Write-Host "Updating PowerShell shortcuts on the Start Menu"
+
+$appdataFolder = $env:APPDATA
+$startFolder = resolve-path "$appdataFolder\Microsoft\Windows\Start Menu"
+$powerShellFolder = resolve-path "$startFolder\Programs\Windows PowerShell"
+
+Write-Host "Looking in $powerShellFolder"
+
+Write-Host
+$powerShellx86 = "$powerShellFolder\Windows PowerShell (x86).lnk"
+if (test-path $powerShellx86) {
+    Write-Host "Updating $powerShellx86"
+    .\Update-Link.ps1 $powerShellx86
+} else {
+    Write-Warning "Didn't find $powerShellx86"
+}
+
+Write-Host
+$powerShell64 = "$powerShellFolder\Windows PowerShell.lnk" 
+if (test-path $powerShell64) {
+    Write-Host "Updating $powerShell64"
+    .\Update-Link.ps1 $powerShell64
+} else {
+    Write-Warning "Didn't find $powerShell64"
+}


### PR DESCRIPTION
Every time I get a new build of windows (I'm on the Windows Insider Fast Ring), I need to restore use of the solarized palette as the update resets them to the standard colours. This script makes that chore a little easier.
