### PR TITLE
Tweaking the color table to match altercation/vim-colors-solarized Vim plugin

### DIFF
--- a/solarized-dark.reg
+++ b/solarized-dark.reg
@@ -8,40 +8,40 @@ Windows Registry Editor Version 5.00
 ;
 ;| SOLARIZED | HEX     | ANSI      | TERMCOL   | cmd.exe     | PowerShell  | ColorTable | DWORD    |
 ;|-----------|---------|-----------|-----------|-------------|-------------|------------|----------|
-;| base03    | #002b36 | ESC[0;30m | brblack   | Black       | Black       | 00         | 00362b00 |
-;| base02    | #073642 | ESC[1;30m | black     | Gray        | DarkGray    | 08         | 00423607 |
-;| base01    | #586e75 | ESC[0;32m | brgreen   | Green       | DarkGreen   | 02         | 00756e58 |
-;| base00    | #657b83 | ESC[0;33m | bryellow  | Yellow      | DarkYellow  | 06         | 00837b65 |
-;| base0     | #839496 | ESC[0;34m | brblue    | Blue        | DarkBlue    | 01         | 00969483 |
-;| base1     | #93a1a1 | ESC[0;36m | brcyan    | Aqua        | DarkCyan    | 03         | 00a1a193 |
+;| base02    | #073642 | ESC[1;30m | black     | Gray        | DarkGray    | 00         | 00423607 |
+;| blue      | #268bd2 | ESC[1;34m | blue      | LightBlue   | Blue        | 01         | 00d28b26 |
+;| green     | #859900 | ESC[1;32m | green     | LightGreen  | Green       | 02         | 00009985 |
+;| cyan      | #2aa198 | ESC[1;36m | cyan      | LightAqua   | Cyan        | 03         | 0098a12a |
+;| red       | #dc322f | ESC[1;31m | red       | LightRed    | Red         | 04         | 002f32dc |
+;| magenta   | #d33682 | ESC[1;35m | magenta   | LightPurple | Magenta     | 05         | 008236d3 |
+;| yellow    | #b58900 | ESC[1;33m | yellow    | LightYellow | Yellow      | 06         | 000089b5 |
 ;| base2     | #eee8d5 | ESC[0;37m | white     | White       | Gray        | 07         | 00d5e8ee |
+;| base03    | #002b36 | ESC[0;30m | brblack   | Black       | Black       | 08         | 00362b00 |
+;| base0     | #839496 | ESC[0;34m | brblue    | Blue        | DarkBlue    | 09         | 00969483 |
+;| base01    | #586e75 | ESC[0;32m | brgreen   | Green       | DarkGreen   | 10         | 00756e58 |
+;| base1     | #93a1a1 | ESC[0;36m | brcyan    | Aqua        | DarkCyan    | 11         | 00a1a193 |
+;| orange    | #cb4b16 | ESC[0;31m | brred     | Red         | DarkRed     | 12         | 00164bcb |
+;| violet    | #6c71c4 | ESC[0;35m | brmagenta | Purple      | DarkMagenta | 13         | 00c4716c |
+;| base00    | #657b83 | ESC[0;33m | bryellow  | Yellow      | DarkYellow  | 14         | 00837b65 |
 ;| base3     | #fdf6e3 | ESC[1;37m | brwhite   | BrightWhite | White       | 15         | 00e3f6fd |
-;| yellow    | #b58900 | ESC[1;33m | yellow    | LightYellow | Yellow      | 14         | 000089b5 |
-;| orange    | #cb4b16 | ESC[0;31m | brred     | Red         | DarkRed     | 04         | 00164bcb |
-;| red       | #dc322f | ESC[1;31m | red       | LightRed    | Red         | 12         | 002f32dc |
-;| magenta   | #d33682 | ESC[1;35m | magenta   | LightPurple | Magenta     | 13         | 008236d3 |
-;| violet    | #6c71c4 | ESC[0;35m | brmagenta | Purple      | DarkMagenta | 05         | 00c4716c |
-;| blue      | #268bd2 | ESC[1;34m | blue      | LightBlue   | Blue        | 09         | 00d28b26 |
-;| cyan      | #2aa198 | ESC[1;36m | cyan      | LightAqua   | Cyan        | 11         | 0098a12a |
-;| green     | #859900 | ESC[1;32m | green     | LightGreen  | Green       | 10         | 00009985 |
 ;
 
 [HKEY_CURRENT_USER\Console]
-"ColorTable00"=dword:00362b00
-"ColorTable01"=dword:00969483
-"ColorTable02"=dword:00756e58
-"ColorTable03"=dword:00a1a193
-"ColorTable04"=dword:00164bcb
-"ColorTable05"=dword:00c4716c
-"ColorTable06"=dword:00837b65
+"ColorTable00"=dword:00423607
+"ColorTable01"=dword:00d28b26
+"ColorTable02"=dword:00009985
+"ColorTable03"=dword:0098a12a
+"ColorTable04"=dword:002f32dc
+"ColorTable05"=dword:008236d3
+"ColorTable06"=dword:000089b5
 "ColorTable07"=dword:00d5e8ee
-"ColorTable08"=dword:00423607
-"ColorTable09"=dword:00d28b26
-"ColorTable10"=dword:00009985
-"ColorTable11"=dword:0098a12a
-"ColorTable12"=dword:002f32dc
-"ColorTable13"=dword:008236d3
-"ColorTable14"=dword:000089b5
+"ColorTable08"=dword:00362b00
+"ColorTable09"=dword:00969483
+"ColorTable10"=dword:00756e58
+"ColorTable11"=dword:00a1a193
+"ColorTable12"=dword:00164bcb
+"ColorTable13"=dword:00c4716c
+"ColorTable14"=dword:00837b65
 "ColorTable15"=dword:00e3f6fd
 "ScreenColors"=dword:00000001
 "PopupColors"=dword:000000f6

--- a/solarized-light.reg
+++ b/solarized-light.reg
@@ -8,40 +8,40 @@ Windows Registry Editor Version 5.00
 ;
 ;| SOLARIZED | HEX     | ANSI      | TERMCOL   | cmd.exe     | PowerShell  | ColorTable | DWORD    |
 ;|-----------|---------|-----------|-----------|-------------|-------------|------------|----------|
-;| base03    | #002b36 | ESC[0;30m | brblack   | Black       | Black       | 00         | 00362b00 |
-;| base02    | #073642 | ESC[1;30m | black     | Gray        | DarkGray    | 08         | 00423607 |
-;| base01    | #586e75 | ESC[0;32m | brgreen   | Green       | DarkGreen   | 02         | 00756e58 |
-;| base00    | #657b83 | ESC[0;33m | bryellow  | Yellow      | DarkYellow  | 06         | 00837b65 |
-;| base0     | #839496 | ESC[0;34m | brblue    | Blue        | DarkBlue    | 01         | 00969483 |
-;| base1     | #93a1a1 | ESC[0;36m | brcyan    | Aqua        | DarkCyan    | 03         | 00a1a193 |
+;| base02    | #073642 | ESC[1;30m | black     | Gray        | DarkGray    | 00         | 00423607 |
+;| blue      | #268bd2 | ESC[1;34m | blue      | LightBlue   | Blue        | 01         | 00d28b26 |
+;| green     | #859900 | ESC[1;32m | green     | LightGreen  | Green       | 02         | 00009985 |
+;| cyan      | #2aa198 | ESC[1;36m | cyan      | LightAqua   | Cyan        | 03         | 0098a12a |
+;| red       | #dc322f | ESC[1;31m | red       | LightRed    | Red         | 04         | 002f32dc |
+;| magenta   | #d33682 | ESC[1;35m | magenta   | LightPurple | Magenta     | 05         | 008236d3 |
+;| yellow    | #b58900 | ESC[1;33m | yellow    | LightYellow | Yellow      | 06         | 000089b5 |
 ;| base2     | #eee8d5 | ESC[0;37m | white     | White       | Gray        | 07         | 00d5e8ee |
+;| base03    | #002b36 | ESC[0;30m | brblack   | Black       | Black       | 08         | 00362b00 |
+;| base0     | #839496 | ESC[0;34m | brblue    | Blue        | DarkBlue    | 09         | 00969483 |
+;| base01    | #586e75 | ESC[0;32m | brgreen   | Green       | DarkGreen   | 10         | 00756e58 |
+;| base1     | #93a1a1 | ESC[0;36m | brcyan    | Aqua        | DarkCyan    | 11         | 00a1a193 |
+;| orange    | #cb4b16 | ESC[0;31m | brred     | Red         | DarkRed     | 12         | 00164bcb |
+;| violet    | #6c71c4 | ESC[0;35m | brmagenta | Purple      | DarkMagenta | 13         | 00c4716c |
+;| base00    | #657b83 | ESC[0;33m | bryellow  | Yellow      | DarkYellow  | 14         | 00837b65 |
 ;| base3     | #fdf6e3 | ESC[1;37m | brwhite   | BrightWhite | White       | 15         | 00e3f6fd |
-;| yellow    | #b58900 | ESC[1;33m | yellow    | LightYellow | Yellow      | 14         | 000089b5 |
-;| orange    | #cb4b16 | ESC[0;31m | brred     | Red         | DarkRed     | 04         | 00164bcb |
-;| red       | #dc322f | ESC[1;31m | red       | LightRed    | Red         | 12         | 002f32dc |
-;| magenta   | #d33682 | ESC[1;35m | magenta   | LightPurple | Magenta     | 13         | 008236d3 |
-;| violet    | #6c71c4 | ESC[0;35m | brmagenta | Purple      | DarkMagenta | 05         | 00c4716c |
-;| blue      | #268bd2 | ESC[1;34m | blue      | LightBlue   | Blue        | 09         | 00d28b26 |
-;| cyan      | #2aa198 | ESC[1;36m | cyan      | LightAqua   | Cyan        | 11         | 0098a12a |
-;| green     | #859900 | ESC[1;32m | green     | LightGreen  | Green       | 10         | 00009985 |
 ;
 
 [HKEY_CURRENT_USER\Console]
-"ColorTable00"=dword:00362b00
-"ColorTable01"=dword:00969483
-"ColorTable02"=dword:00756e58
-"ColorTable03"=dword:00a1a193
-"ColorTable04"=dword:00164bcb
-"ColorTable05"=dword:00c4716c
-"ColorTable06"=dword:00837b65
+"ColorTable00"=dword:00423607
+"ColorTable01"=dword:00d28b26
+"ColorTable02"=dword:00009985
+"ColorTable03"=dword:0098a12a
+"ColorTable04"=dword:002f32dc
+"ColorTable05"=dword:008236d3
+"ColorTable06"=dword:000089b5
 "ColorTable07"=dword:00d5e8ee
-"ColorTable08"=dword:00423607
-"ColorTable09"=dword:00d28b26
-"ColorTable10"=dword:00009985
-"ColorTable11"=dword:0098a12a
-"ColorTable12"=dword:002f32dc
-"ColorTable13"=dword:008236d3
-"ColorTable14"=dword:000089b5
+"ColorTable08"=dword:00362b00
+"ColorTable09"=dword:00969483
+"ColorTable10"=dword:00756e58
+"ColorTable11"=dword:00a1a193
+"ColorTable12"=dword:00164bcb
+"ColorTable13"=dword:00c4716c
+"ColorTable14"=dword:00837b65
 "ColorTable15"=dword:00e3f6fd
 "ScreenColors"=dword:000000f6
 "PopupColors"=dword:00000001


### PR DESCRIPTION
I tweaked the colors on the table so Vim gets the solarized colors when using the https://github.com/altercation/vim-colors-solarized plugin