### PR TITLE
Add option to use Unix Solarized color assignments

### DIFF
--- a/Update-Link.ps1
+++ b/Update-Link.ps1
@@ -5,42 +5,79 @@ param(
 
     [Parameter()]
     [ValidateSet('Light','Dark')]
-    [string]$Theme = 'Dark'
+    [string]$Theme = 'Dark',
+
+    [Parameter()]
+    [ValidateSet('Windows','Unix')]
+    [string]$Shell = 'Windows'
 )
 
 $lnk = & ("$PSScriptRoot\Get-Link.ps1") $Path
 
-# Set Common Solarized Colors
-$lnk.ConsoleColors[0]="#002b36"
-$lnk.ConsoleColors[8]="#073642"
-$lnk.ConsoleColors[2]="#586e75"
-$lnk.ConsoleColors[6]="#657b83"
-$lnk.ConsoleColors[1]="#839496"
-$lnk.ConsoleColors[3]="#93a1a1"
-$lnk.ConsoleColors[7]="#eee8d5"
-$lnk.ConsoleColors[15]="#fdf6e3"
-$lnk.ConsoleColors[14]="#b58900"
-$lnk.ConsoleColors[4]="#cb4b16"
-$lnk.ConsoleColors[12]="#dc322f"
-$lnk.ConsoleColors[13]="#d33682"
-$lnk.ConsoleColors[5]="#6c71c4"
-$lnk.ConsoleColors[9]="#268bd2"
-$lnk.ConsoleColors[11]="#2aa198"
-$lnk.ConsoleColors[10]="#859900"
+if ($Shell -eq "Windows") {
+    # Set Common Solarized Colors
+    $lnk.ConsoleColors[0]="#002b36"
+    $lnk.ConsoleColors[8]="#073642"
+    $lnk.ConsoleColors[2]="#586e75"
+    $lnk.ConsoleColors[6]="#657b83"
+    $lnk.ConsoleColors[1]="#839496"
+    $lnk.ConsoleColors[3]="#93a1a1"
+    $lnk.ConsoleColors[7]="#eee8d5"
+    $lnk.ConsoleColors[15]="#fdf6e3"
+    $lnk.ConsoleColors[14]="#b58900"
+    $lnk.ConsoleColors[4]="#cb4b16"
+    $lnk.ConsoleColors[12]="#dc322f"
+    $lnk.ConsoleColors[13]="#d33682"
+    $lnk.ConsoleColors[5]="#6c71c4"
+    $lnk.ConsoleColors[9]="#268bd2"
+    $lnk.ConsoleColors[11]="#2aa198"
+    $lnk.ConsoleColors[10]="#859900"
 
-# Set Light/Dark Theme-Specific Colors
-if ($Theme -eq "Dark") {
-    $lnk.PopUpBackgroundColor=0xf
-    $lnk.PopUpTextColor=0x6
-    $lnk.ScreenBackgroundColor=0x0
-    $lnk.ScreenTextColor=0x1
+    # Set Light/Dark Theme-Specific Colors
+    if ($Theme -eq "Dark") {
+        $lnk.PopUpBackgroundColor=0xf
+        $lnk.PopUpTextColor=0x6
+        $lnk.ScreenBackgroundColor=0x0
+        $lnk.ScreenTextColor=0x1
+    } else {
+        $lnk.PopUpBackgroundColor=0x0
+        $lnk.PopUpTextColor=0x1
+        $lnk.ScreenBackgroundColor=0xf
+        $lnk.ScreenTextColor=0x6
+    }
 } else {
-    $lnk.PopUpBackgroundColor=0x0
-    $lnk.PopUpTextColor=0x1
-    $lnk.ScreenBackgroundColor=0xf
-    $lnk.ScreenTextColor=0x6
+    # Set Common Solarized Colors
+    $lnk.ConsoleColors[8]="#002b36"
+    $lnk.ConsoleColors[0]="#073642"
+    $lnk.ConsoleColors[10]="#586e75"
+    $lnk.ConsoleColors[14]="#657b83"
+    $lnk.ConsoleColors[9]="#839496"
+    $lnk.ConsoleColors[11]="#93a1a1"
+    $lnk.ConsoleColors[7]="#eee8d5"
+    $lnk.ConsoleColors[15]="#fdf6e3"
+    $lnk.ConsoleColors[6]="#b58900"
+    $lnk.ConsoleColors[12]="#cb4b16"
+    $lnk.ConsoleColors[4]="#dc322f"
+    $lnk.ConsoleColors[5]="#d33682"
+    $lnk.ConsoleColors[13]="#6c71c4"
+    $lnk.ConsoleColors[1]="#268bd2"
+    $lnk.ConsoleColors[3]="#2aa198"
+    $lnk.ConsoleColors[2]="#859900"
+
+    # Set Light/Dark Theme-Specific Colors
+    if ($Theme -eq "Dark") {
+        $lnk.PopUpBackgroundColor=0xf
+        $lnk.PopUpTextColor=0xe
+        $lnk.ScreenBackgroundColor=0x8
+        $lnk.ScreenTextColor=0x9
+    } else {
+        $lnk.PopUpBackgroundColor=0x8
+        $lnk.PopUpTextColor=0x9
+        $lnk.ScreenBackgroundColor=0xf
+        $lnk.ScreenTextColor=0xe
+    }
 }
 
 $lnk.Save()
 
-Write-Host "Updated $Path to Solarized - $Theme"
+Write-Host "Updated $Path to Solarized - $Theme for $Shell shell"


### PR DESCRIPTION
Adds a 'Shell' parameter to Update-Link. It takes two values 'Windows'
is the default and maintains the existing behaviour. 'Unix' assigns
Solarized colors to the same ANSI color escape codes as the terminal
emulator themes linked to from https://ethanschoonover.com/solarized/.

The Unix option allows Solarized themes for Unix tools like
https://github.com/seebi/dircolors-solarized work correctly and is
designed to be used with Cygwin or WSL.