### PR TITLE
Update PSReadLine configuration

### DIFF
--- a/Set-SolarizedDarkColorDefaults.ps1
+++ b/Set-SolarizedDarkColorDefaults.ps1
@@ -14,35 +14,19 @@ $Host.PrivateData.ProgressBackgroundColor = 'Cyan'
 
 # Check for PSReadline
 if (Get-Module -ListAvailable -Name "PSReadline") {
-    $options = Get-PSReadlineOption
-
-    # Foreground
-    $options.CommandForegroundColor = 'Yellow'
-    $options.ContinuationPromptForegroundColor = 'DarkBlue'
-    $options.DefaultTokenForegroundColor = 'DarkBlue'
-    $options.EmphasisForegroundColor = 'Cyan'
-    $options.ErrorForegroundColor = 'Red'
-    $options.KeywordForegroundColor = 'Green'
-    $options.MemberForegroundColor = 'DarkCyan'
-    $options.NumberForegroundColor = 'DarkCyan'
-    $options.OperatorForegroundColor = 'DarkGreen'
-    $options.ParameterForegroundColor = 'DarkGreen'
-    $options.StringForegroundColor = 'Blue'
-    $options.TypeForegroundColor = 'DarkYellow'
-    $options.VariableForegroundColor = 'Green'
-
-    # Background
-    $options.CommandBackgroundColor = 'Black'
-    $options.ContinuationPromptBackgroundColor = 'Black'
-    $options.DefaultTokenBackgroundColor = 'Black'
-    $options.EmphasisBackgroundColor = 'Black'
-    $options.ErrorBackgroundColor = 'Black'
-    $options.KeywordBackgroundColor = 'Black'
-    $options.MemberBackgroundColor = 'Black'
-    $options.NumberBackgroundColor = 'Black'
-    $options.OperatorBackgroundColor = 'Black'
-    $options.ParameterBackgroundColor = 'Black'
-    $options.StringBackgroundColor = 'Black'
-    $options.TypeBackgroundColor = 'Black'
-    $options.VariableBackgroundColor = 'Black'
+    Set-PSReadLineOption -Colors @{ 
+        "Command"            = [ConsoleColor]::Yellow
+        "ContinuationPrompt" = [ConsoleColor]::DarkBlue
+        "DefaultToken"       = [ConsoleColor]::DarkBlue
+        "Emphasis"           = [ConsoleColor]::Cyan
+        "Error"              = [ConsoleColor]::Red
+        "Keyword"            = [ConsoleColor]::Green
+        "Member"             = [ConsoleColor]::DarkCyan
+        "Number"             = [ConsoleColor]::DarkCyan
+        "Operator"           = [ConsoleColor]::DarkGreen
+        "Parameter"          = [ConsoleColor]::DarkGreen
+        "String"             = [ConsoleColor]::Blue
+        "Type"               = [ConsoleColor]::DarkYellow
+        "Variable"           = [ConsoleColor]::Green
+    }
 }

--- a/Set-SolarizedLightColorDefaults.ps1
+++ b/Set-SolarizedLightColorDefaults.ps1
@@ -14,35 +14,19 @@ $Host.PrivateData.ProgressBackgroundColor = 'Cyan'
 
 # Check for PSReadline
 if (Get-Module -ListAvailable -Name "PSReadline") {
-    $options = Get-PSReadlineOption
-
-    # Foreground
-    $options.CommandForegroundColor = 'Yellow'
-    $options.ContinuationPromptForegroundColor = 'DarkYellow'
-    $options.DefaultTokenForegroundColor = 'DarkYellow'
-    $options.EmphasisForegroundColor = 'Cyan'
-    $options.ErrorForegroundColor = 'Red'
-    $options.KeywordForegroundColor = 'Green'
-    $options.MemberForegroundColor = 'DarkGreen'
-    $options.NumberForegroundColor = 'DarkGreen'
-    $options.OperatorForegroundColor = 'DarkCyan'
-    $options.ParameterForegroundColor = 'DarkCyan'
-    $options.StringForegroundColor = 'Blue'
-    $options.TypeForegroundColor = 'DarkBlue'
-    $options.VariableForegroundColor = 'Green'
-
-    # Background
-    $options.CommandBackgroundColor = 'White'
-    $options.ContinuationPromptBackgroundColor = 'White'
-    $options.DefaultTokenBackgroundColor = 'White'
-    $options.EmphasisBackgroundColor = 'White'
-    $options.ErrorBackgroundColor = 'White'
-    $options.KeywordBackgroundColor = 'White'
-    $options.MemberBackgroundColor = 'White'
-    $options.NumberBackgroundColor = 'White'
-    $options.OperatorBackgroundColor = 'White'
-    $options.ParameterBackgroundColor = 'White'
-    $options.StringBackgroundColor = 'White'
-    $options.TypeBackgroundColor = 'White'
-    $options.VariableBackgroundColor = 'White'
+    Set-PSReadLineOption -Colors @{
+        "Command"            = [ConsoleColor]::Yellow
+        "ContinuationPrompt" = [ConsoleColor]::DarkYellow
+        "DefaultToken"       = [ConsoleColor]::DarkYellow
+        "Emphasis"           = [ConsoleColor]::Cyan
+        "Error"              = [ConsoleColor]::Red
+        "Keyword"            = [ConsoleColor]::Green
+        "Member"             = [ConsoleColor]::DarkGreen
+        "Number"             = [ConsoleColor]::DarkGreen
+        "Operator"           = [ConsoleColor]::DarkCyan
+        "Parameter"          = [ConsoleColor]::DarkCyan
+        "String"             = [ConsoleColor]::Blue
+        "Type"               = [ConsoleColor]::DarkBlue
+        "Variable"           = [ConsoleColor]::Green
+    }
 }


### PR DESCRIPTION
The relatively new PowerShell ReadLine release introduced backward-incompatible changes to profile scripts configuring the terminal colors. The `ps1` scripts in this repository produce console errors when run as-is.

This pull request updates the scripts to the more recently-adopted syntax, without changing any aesthetic behaviors.

See the following GitHub issue for details: https://github.com/lzybkr/PSReadLine/issues/738