### PR TITLE
reuse exisiting global $options variable

### DIFF
--- a/Set-SolarizedDarkColorDefaults.ps1
+++ b/Set-SolarizedDarkColorDefaults.ps1
@@ -14,8 +14,7 @@ $Host.PrivateData.ProgressBackgroundColor = 'Cyan'
 
 # Check for PSReadline
 if (Get-Module -ListAvailable -Name "PSReadline") {
-    $options = Get-PSReadlineOption
-
+        if (-not $options){ $options = Get-PSReadlineOption }
 	if ([System.Version](Get-Module PSReadline).Version -lt [System.Version]"2.0.0") {
 		# Foreground
 		$options.CommandForegroundColor = 'Yellow'

--- a/Set-SolarizedLightColorDefaults.ps1
+++ b/Set-SolarizedLightColorDefaults.ps1
@@ -14,8 +14,7 @@ $Host.PrivateData.ProgressBackgroundColor = 'Cyan'
 
 # Check for PSReadline
 if (Get-Module -ListAvailable -Name "PSReadline") {
-    $options = Get-PSReadlineOption
-
+    if (-not $options){ $options = Get-PSReadlineOption }
 	if ([System.Version](Get-Module PSReadline).Version -lt [System.Version]"2.0.0") {
 		# Foreground
 		$options.CommandForegroundColor = 'Yellow'


### PR DESCRIPTION
This avoids a clash with other global `$options` variables defined [elsewhere](https://github.com/badmotorfinger/z/blob/a55a57ee05db2abbf7130d7cf350b0b371de5771/z.psm1#L673)